### PR TITLE
Fix the go module name as changed to gke-windows-builder

### DIFF
--- a/gke-windows-builder/builder/go.mod
+++ b/gke-windows-builder/builder/go.mod
@@ -1,4 +1,4 @@
-module windows-cloudbuild-builder/builder
+module gke-windows-builder/builder
 
 go 1.13
 

--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"windows-cloudbuild-builder/builder/builder"
+	"gke-windows-builder/builder/builder"
 
 	"github.com/masterzen/winrm"
 	"google.golang.org/api/googleapi"


### PR DESCRIPTION
Update the go module name as the folder name changed to gke-windows-builder.