### PR TITLE
Distribute entire source tarball inside of gke-windows-builder container

### DIFF
--- a/gke-windows-builder/README.md
+++ b/gke-windows-builder/README.md
@@ -1,9 +1,7 @@
 # Description
 
-This tool is used to create a GKE Windows builder to build multi-arch
-containers using Cloud Build.
-
-Customized from
+This tool is used to create a Docker container image that can build Windows
+multi-arch container images using Google Cloud Build. This tool was forked from
 [cloud-builders-community/windows-builder](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/windows-builder).
 
 # Maintaining this builder
@@ -43,7 +41,9 @@ gcloud compute firewall-rules create allow-winrm-ingress --allow=tcp:5986 --dire
 
 ### Build steps
 
-The "official" build is performed using Cloud Build:
+The "official" build uses Google Cloud Build to build the builder tool (a Linux
+Go binary) and install it in a Docker container image that is pushed to Google
+Container Registry. Run this command to invoke Cloud Build:
 
 ```shell
 gcloud builds submit --config=builder/cloudbuild.yaml builder/
@@ -69,9 +69,10 @@ If you visit
 you should now see the `latest` builder image that you just built and pushed.
 
 As part of the Cloud Build process you'll see output showing the `go build` step
-that builds the Go code you may be modifying. To reduce your dev/build cycle
-time, you can copy and modify the command from this step and run it directly
-(from the `builder/` subdir), something like:
+that builds the Go code you may be modifying. To reduce the dev/build cycle time
+when making changes to the builder's Go code, you can copy and adjust the
+command from this step and run it directly (from the `builder/` subdir),
+something like:
 
 ```shell
 GO111MODULE=on CGO_ENABLED=0 go build -o /tmp/go/bin/gke-windows-builder_main

--- a/gke-windows-builder/builder/Dockerfile
+++ b/gke-windows-builder/builder/Dockerfile
@@ -3,8 +3,16 @@ FROM golang AS build-env
 ADD ./ /go/src/builder
 WORKDIR /go/src/builder
 
+# Build the builder tool.
 RUN GO111MODULE=on CGO_ENABLED=0 go build -o /go/bin/main
+
+# Create a source tarball to distribute inside of the container image. Omit
+# the mod/cache/ dir which just contains .mod files, not source code files.
+# The size of the tarball is just under 50 MB.
+RUN rm -rf /go/pkg/mod/cache
+RUN tar -c /go/pkg/mod/* /go/src/builder -z -f /gke-windows-builder-source.tar.gz
 
 FROM gcr.io/distroless/base-debian10
 COPY --from=build-env /go/bin/main /bin/main
+COPY --from=build-env /gke-windows-builder-source.tar.gz /
 ENTRYPOINT [ "/bin/main" ]


### PR DESCRIPTION
Updates the Dockerfile to package the builder source code into a tarball and include it in the container image. Also makes some small updates to the README.

====Tested:====
`gcloud builds submit --config=builder/cloudbuild.yaml builder/`
    https://console.cloud.google.com/cloud-build/builds/5b247057-b1db-453c-bd00-a93ef6433859?project=895776186405