### PR TITLE
Enable pushing result image to artifacts registry

### DIFF
--- a/gke-windows-builder/README.md
+++ b/gke-windows-builder/README.md
@@ -25,14 +25,16 @@ export MEMBER=$(gcloud projects describe $PROJECT --format 'value(projectNumber)
 # Enable the Cloud Build and Compute APIs on your project:
 gcloud services enable cloudbuild.googleapis.com
 gcloud services enable compute.googleapis.com
+gcloud services enable artifactregistry.googleapis.com
 
 # Assign roles. These roles are required for the builder to create the Windows
-# Server VMs, to copy the workspace to a Cloud Storage bucket and to configure the
-# networks to build the Docker image:
+# Server VMs, to copy the workspace to a Cloud Storage bucket, to configure the
+# networks to build the Docker image and to push resulting image to artifact registry:
 gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$MEMBER --role='roles/compute.instanceAdmin'
 gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$MEMBER --role='roles/iam.serviceAccountUser'
 gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$MEMBER --role='roles/compute.networkViewer'
 gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$MEMBER --role='roles/storage.admin'
+gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$MEMBER --role='roles/artifactregistry.writer'
 
 # Add a firewall rule named allow-winrm-ingress to allow WinRM to connect to
 # Windows Server VMs to run a Docker build:

--- a/gke-windows-builder/builder/cloudbuild.yaml
+++ b/gke-windows-builder/builder/cloudbuild.yaml
@@ -14,6 +14,6 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/gke-windows-builder', '.' ]
+  args: [ 'build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/docker-repo/gke-windows-builder', '.' ]
 images:
-- 'gcr.io/$PROJECT_ID/gke-windows-builder'
+- 'us-docker.pkg.dev/$PROJECT_ID/docker-repo/gke-windows-builder'

--- a/gke-windows-builder/example/basic/cloudbuild.yaml
+++ b/gke-windows-builder/example/basic/cloudbuild.yaml
@@ -14,8 +14,8 @@
 
 timeout: 3600s
 steps:
-  - name: 'gcr.io/$PROJECT_ID/gke-windows-builder'
+  - name: 'us-docker.pkg.dev/$PROJECT_ID/docker-repo/gke-windows-builder'
     args:
     - --container-image-name
-    - 'gcr.io/$PROJECT_ID/windows-multiarch-container-demo:cloudbuild'
+    - 'us-docker.pkg.dev/$PROJECT_ID/docker-repo/windows-multiarch-container-demo:cloudbuild'
 tags: ['cloud-builders-community']


### PR DESCRIPTION
To push result image to artifacts registry(AR), need to
1. Enable AR service API
2. Grant `roles/artifactregistry.writer` to Cloud Builder
3. Authenticate Docker thru https://cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper