### PR TITLE
Added flag use-internal-ip to allow for internal IP on shared VPCs

### DIFF
--- a/gke-windows-builder/builder/builder/remote.go
+++ b/gke-windows-builder/builder/builder/remote.go
@@ -46,6 +46,7 @@ type WindowsBuildServerConfig struct {
 	ServiceAccount *string
 	BootDiskType   *string
 	BootDiskSizeGB int64
+	UseInternalIP  bool
 }
 
 // Wait for server to be available for Winrm connection and Docker setup.

--- a/gke-windows-builder/example/shared-vpc/cloudbuild.yaml
+++ b/gke-windows-builder/example/shared-vpc/cloudbuild.yaml
@@ -20,6 +20,7 @@ steps:
     - 'gcr.io/$PROJECT_ID/gke-windows-builder-example-shared-vpc:latest'
     - --machineType
     - 'n1-standard-8'
+    - --use-internal-ip
     - --subnetwork-project
     - 'shared-vpc-host-project-317922'
     - --subnetwork


### PR DESCRIPTION
To support internal IPs on shared VPCs add a flag to skip firewall rule checks and use internal ip when connecting instead of external