### PR TITLE
Add a flag to support VM creation without external IP

### DIFF
--- a/gke-windows-builder/README.md
+++ b/gke-windows-builder/README.md
@@ -41,6 +41,10 @@ gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$MEMBER 
 gcloud compute firewall-rules create allow-winrm-ingress --allow=tcp:5986 --direction=INGRESS
 ```
 
+### One-time setup if you want to use internal IP only VMs
+
+Please enable Cloud NAT in your project and create a worker pool with VPC peering to the subnet in which the windows builders will run
+
 ### Build steps
 
 The "official" build uses Google Cloud Build to build the builder tool (a Linux

--- a/gke-windows-builder/builder/builder/gce.go
+++ b/gke-windows-builder/builder/builder/gce.go
@@ -215,7 +215,7 @@ func (s *Server) newInstance(bs *WindowsBuildServerConfig) error {
 		},
 	}
 
-	if bs.UseInternalIP {
+	if !bs.ExternalNAT {
 		accessConfigs = nil
 	}
 

--- a/gke-windows-builder/builder/builder/gce.go
+++ b/gke-windows-builder/builder/builder/gce.go
@@ -208,6 +208,17 @@ func (s *Server) newInstance(bs *WindowsBuildServerConfig) error {
 		machineType = "e2-standard-2"
 	}
 
+	accessConfigs := []*compute.AccessConfig{
+		{
+			Type: "ONE_TO_ONE_NAT",
+			Name: "External NAT",
+		},
+	}
+
+	if bs.UseInternalIP {
+		accessConfigs = nil
+	}
+
 	// https://cloud.google.com/compute/docs/reference/rest/v1/instances#resource:-instance
 	instance := &compute.Instance{
 		Name:        name,
@@ -235,12 +246,7 @@ func (s *Server) newInstance(bs *WindowsBuildServerConfig) error {
 		},
 		NetworkInterfaces: []*compute.NetworkInterface{
 			&compute.NetworkInterface{
-				AccessConfigs: []*compute.AccessConfig{
-					&compute.AccessConfig{
-						Type: "ONE_TO_ONE_NAT",
-						Name: "External NAT",
-					},
-				},
+				AccessConfigs: accessConfigs,
 			},
 		},
 		ServiceAccounts: []*compute.ServiceAccount{

--- a/gke-windows-builder/builder/builder/remote.go
+++ b/gke-windows-builder/builder/builder/remote.go
@@ -47,6 +47,7 @@ type WindowsBuildServerConfig struct {
 	BootDiskType   *string
 	BootDiskSizeGB int64
 	UseInternalIP  bool
+	ExternalNAT    bool
 }
 
 // Wait for server to be available for Winrm connection and Docker setup.

--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -51,7 +51,7 @@ var (
 	testObsoleteVersion = flag.Bool("testonly-test-obsolete-versions", false, "If true, verify the obsolete Windows versions won't fail the builder. For testing purposes only")
 	setupTimeout        = flag.Duration("setup-timeout", 20*time.Minute, "Time out to wait for Windows instance to be ready for winrm connection and Docker setup")
 	useInternalIP       = flag.Bool("use-internal-ip", false, "Use internal IP addresses (for shared VPCs), also implies no need for firewall rules")
-	ExternalIP          = flag.Bool("external-ip", true, "Create external IP addresses for VMs, please note that if a builder needs to download a base image from outside of gcr Cloud NAT will have to be enabled")
+	ExternalIP          = flag.Bool("external-ip", true, "Create external IP addresses for VMs, If false then Cloud NAT must be enabled, see README for details.")
 	skipFirewallCheck   = flag.Bool("skip-firewall-check", false, "Skip checking that the project has a firewall rule permitting WinRM ingress")
 	// Windows version and GCE container image family map
 	// Note:

--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -51,6 +51,7 @@ var (
 	testObsoleteVersion = flag.Bool("testonly-test-obsolete-versions", false, "If true, verify the obsolete Windows versions won't fail the builder. For testing purposes only")
 	setupTimeout        = flag.Duration("setup-timeout", 20*time.Minute, "Time out to wait for Windows instance to be ready for winrm connection and Docker setup")
 	useInternalIP       = flag.Bool("use-internal-ip", false, "Use internal IP addresses (for shared VPCs), also implies no need for firewall rules")
+	ExternalIP          = flag.Bool("external-ip", true, "Create external IP addresses for VMs, please note that if a builder needs to download a base image from outside of gcr Cloud NAT will have to be enabled")
 	skipFirewallCheck   = flag.Bool("skip-firewall-check", false, "Skip checking that the project has a firewall rule permitting WinRM ingress")
 	// Windows version and GCE container image family map
 	// Note:
@@ -230,6 +231,7 @@ func buildSingleArchContainer(ctx context.Context, ver string, imageFamily strin
 		BootDiskSizeGB: *bootDiskSizeGB,
 		ServiceAccount: serviceAccount,
 		UseInternalIP:  *useInternalIP,
+		ExternalNAT:    *ExternalIP,
 	}
 	s, err := builder.NewServer(ctx, bsc, *projectID)
 	if err != nil {


### PR DESCRIPTION
When working with internal IP in a shared VPC there might not be any reason to create an external IP to the VM.
And since external IP have quotas you can't have too many builds using it.

We can't do it by default when using internal IP since access to external repositories will require Cloud NAT to be enabled and it has costs associated with it.