### PR TITLE
Add a daemonset sample for image pre-pull on GKE Windows nodes

### DIFF
--- a/prepull-daemonset/README.md
+++ b/prepull-daemonset/README.md
@@ -5,24 +5,28 @@ The daemonset can be used to pre-pull large images to [Windows node pools on GKE
 # Configuring the daemonset
 
 A list of desired images that is required to be pre-pulled on every Windows node can be specified in [daemonset.yaml](daemonset.yaml):
-```          pull gcr.io/my-registry/image-1:tag1 &&
+```
+          pull gcr.io/my-registry/image-1:tag1 &&
           pull gcr.io/my-registry/image-2@sha256:some-digest
 ```
 
-The daemonset initContainer uses a [nanoserver image](https://hub.docker.com/_/microsoft-windows-nanoserver) to run. :1809 tag supoorts Windows Server LTSC (2019). Please adjust to the prober LTSC or SAC tag as needed:
-```      - name: pre-pull-large-images
+The daemonset initContainer uses a [nanoserver image](https://hub.docker.com/_/microsoft-windows-nanoserver) to run. :1809 tag supoorts Windows Server LTSC (2019). Please adjust to the proper LTSC or SAC tag as needed:
+```
+      - name: pre-pull-large-images
         image: mcr.microsoft.com/windows/nanoserver:1809
 ```
 
 # Installation through CLI
 
-```$ kubectl create -f daemonset.yaml
+```
+$ kubectl create -f daemonset.yaml
 ```
 
 # Checking logs
 
 The logs from the daemonset pods shows the output from [crictl](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md) tool used to pre-pull, as an example:
-```$ kubectl logs pre-pull-rl2d7 -c pre-pull-large-images
+```
+$ kubectl logs pre-pull-rl2d7 -c pre-pull-large-images
 
 C:\>tools\crictl --debug pull <some-image-path>   
 time="2022-03-25T18:07:58Z" level=debug msg="get image connection"

--- a/prepull-daemonset/README.md
+++ b/prepull-daemonset/README.md
@@ -1,0 +1,35 @@
+# Description
+
+The daemonset can be used to pre-pull large images to [Windows node pools on GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows). The daemonset supports both Docker and Containerd node pools.
+
+# Configuring the daemonset
+
+A list of desired images that is required to be pre-pulled on every Windows node can be specified in [daemonset.yaml](daemonset.yaml):
+```          pull gcr.io/my-registry/image-1:tag1 &&
+          pull gcr.io/my-registry/image-2@sha256:some-digest
+```
+
+The daemonset initContainer uses a [nanoserver image](https://hub.docker.com/_/microsoft-windows-nanoserver) to run. :1809 tag supoorts Windows Server LTSC (2019). Please adjust to the prober LTSC or SAC tag as needed:
+```      - name: pre-pull-large-images
+        image: mcr.microsoft.com/windows/nanoserver:1809
+```
+
+# Installation through CLI
+
+```$ kubectl create -f daemonset.yaml
+```
+
+# Checking logs
+
+The logs from the daemonset pods shows the output from [crictl](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md) tool used to pre-pull, as an example:
+```$ kubectl logs pre-pull-rl2d7 -c pre-pull-large-images
+
+C:\>tools\crictl --debug pull <some-image-path>   
+time="2022-03-25T18:07:58Z" level=debug msg="get image connection"
+time="2022-03-25T18:07:58Z" level=warning msg="image connect using default endpoints: [npipe:////./pipe/dockershim npipe:////./pipe/containerd npipe:////./pipe/crio]. As the default settings are now deprecated, you should set the endpoint instead."
+time="2022-03-25T18:08:00Z" level=debug msg="connect using endpoint 'npipe:////./pipe/containerd' with '2s' timeout"
+time="2022-03-25T18:08:00Z" level=debug msg="connected successfully using endpoint: npipe:////./pipe/containerd"
+time="2022-03-25T18:08:00Z" level=debug msg="PullImageRequest: &PullImageRequest{Image:&ImageSpec{Image:<some-image-path>,Annotations:map[string]string{},},Auth:nil,SandboxConfig:nil,}"
+time="2022-03-25T18:08:00Z" level=debug msg="PullImageResponse: &PullImageResponse{ImageRef:sha256:<some-digest>,}"
+Image is up to date for sha256:<some-digest>
+```

--- a/prepull-daemonset/daemonset.yaml
+++ b/prepull-daemonset/daemonset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: pre-pull
+  labels:
+    app: pre-pull
+spec:
+  selector:
+    matchLabels:
+      app: pre-pull
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: pre-pull
+    spec:
+      initContainers:
+      - name: pre-pull-large-images
+        image: mcr.microsoft.com/windows/nanoserver:1809
+        securityContext:
+          windowsOptions:
+            runAsUserName: "ContainerAdministrator"
+        command:
+        - cmd
+        - /c
+        args:
+        - echo tools\crictl --debug pull %1 > pull.cmd &&
+          pull gcr.io/my-registry/image-1:tag1 &&
+          pull gcr.io/my-registry/image-2@sha256:some-digest
+        volumeMounts:
+        - name: container-runtime-tools
+          mountPath: "\\tools"
+          readOnly: true
+        - name: dockershim-pipe
+          mountPath: \\.\pipe\dockershim
+        - name: containerd-pipe
+          mountPath: \\.\pipe\containerd
+      containers:
+      - name: no-op
+        image: gcr.io/gke-release/pause-win:1.6.1
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      nodeSelector:
+        kubernetes.io/os: windows
+      volumes:
+      - name: container-runtime-tools
+        hostPath:
+         path: "\\etc\\kubernetes\\node\\bin"
+      - name: dockershim-pipe
+        hostPath:
+          path: \\.\pipe\dockershim
+          type: ""
+      - name: containerd-pipe
+        hostPath:
+          path: \\.\pipe\containerd-containerd
+          type: ""


### PR DESCRIPTION
The change adds a daemonset sample that can be utilized to pre fetch certain images and keep it available on the Windows node pools.