### PR TITLE
Update prepull daemonset to handle auth for private images

### DIFF
--- a/prepull-daemonset/README.md
+++ b/prepull-daemonset/README.md
@@ -1,13 +1,13 @@
 # Description
 
-The daemonset can be used to pre-pull large images to [Windows node pools on GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows). The daemonset supports both Docker and Containerd node pools.
+The daemonset can be used to pre-pull large images to [Windows node pools on GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows). The daemonset supports both Docker and Containerd node pools. Private images on gcr will be accessible if the daemon is running from within the same project, or if proper IAM access is set. 
 
 # Configuring the daemonset
 
 A list of desired images that is required to be pre-pulled on every Windows node can be specified in [daemonset.yaml](daemonset.yaml):
 ```
-          pull gcr.io/my-registry/image-1:tag1 &&
-          pull gcr.io/my-registry/image-2@sha256:some-digest
+          cmd\pull gcr.io/my-registry/image-1:tag1 &&
+          cmd\pull gcr.io/my-registry/image-2@sha256:some-digest
 ```
 
 The daemonset initContainer uses a [nanoserver image](https://hub.docker.com/_/microsoft-windows-nanoserver) to run. :1809 tag supoorts Windows Server LTSC (2019). Please adjust to the proper LTSC or SAC tag as needed:
@@ -19,6 +19,7 @@ The daemonset initContainer uses a [nanoserver image](https://hub.docker.com/_/m
 # Installation through CLI
 
 ```
+$ kubectl create -f pull-image-configmap.yaml
 $ kubectl create -f daemonset.yaml
 ```
 

--- a/prepull-daemonset/daemonset.yaml
+++ b/prepull-daemonset/daemonset.yaml
@@ -25,9 +25,8 @@ spec:
         - cmd
         - /c
         args:
-        - echo tools\crictl --debug pull %1 > pull.cmd &&
-          pull gcr.io/my-registry/image-1:tag1 &&
-          pull gcr.io/my-registry/image-2@sha256:some-digest
+        - cmd\pull gcr.io/my-registry/image-1:tag1 &&
+          cmd\pull gcr.io/my-registry/image-2@sha256:some-digest
         volumeMounts:
         - name: container-runtime-tools
           mountPath: "\\tools"
@@ -36,6 +35,8 @@ spec:
           mountPath: \\.\pipe\dockershim
         - name: containerd-pipe
           mountPath: \\.\pipe\containerd
+        - name: pull-image-volume
+          mountPath: "\\cmd"
       containers:
       - name: no-op
         image: gcr.io/gke-release/pause-win:1.6.1
@@ -47,6 +48,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: windows
       volumes:
+      - name: pull-image-volume
+        configMap:
+          name: pull-image
+          items:
+          - key: pull.cmd
+            path: pull.cmd
       - name: container-runtime-tools
         hostPath:
          path: "\\etc\\kubernetes\\node\\bin"

--- a/prepull-daemonset/pull-image-configmap.yaml
+++ b/prepull-daemonset/pull-image-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  pull.cmd: |
+    ping 10.0.0.0 -n 1 -w 20000
+    set metadata_ep=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
+    set header=^"Metadata-Flavor: Google^"
+    for /f 'delims^=^"^ tokens^=4' %%i in ('curl -H %%header%% %%metadata_ep%%') do (set sa_token=%%i)
+    tools\crictl --debug pull --creds "oauth2accesstoken:%sa_token%" %1
+metadata:
+  name: pull-image
+  namespace: default


### PR DESCRIPTION
The change adds --creds to image pulling through the crictl cli. it'll pass a token to allow pulling gcr private images if the access is set for the project. By default, accessing private images from the same project should work with no additional configurations needed.