### PR TITLE
Support re-using existing windows GCE instances

### DIFF
--- a/gke-windows-builder/builder/builder/gce.go
+++ b/gke-windows-builder/builder/builder/gce.go
@@ -346,11 +346,14 @@ func (s *Server) resetPasswordAndPopulateRemoteServer(useInternalIP bool) error 
 		return err
 	}
 
+	workspaceFolder := fmt.Sprintf(`C:\ws-%s`, uuid.New())
+
 	// Set and return Remote.
 	s.RemoteWindowsServer = RemoteWindowsServer{
-		Hostname: &ip,
-		Username: &username,
-		Password: &password,
+		Hostname:        &ip,
+		Username:        &username,
+		Password:        &password,
+		WorkspaceFolder: &workspaceFolder,
 	}
 
 	return nil

--- a/gke-windows-builder/builder/builder/remote.go
+++ b/gke-windows-builder/builder/builder/remote.go
@@ -51,6 +51,7 @@ type WindowsBuildServerConfig struct {
 	BootDiskSizeGB     int64
 	UseInternalIP      bool
 	ExternalNAT        bool
+	ReuseInstance      bool
 }
 
 // Wait for server to be available for Winrm connection and Docker setup.
@@ -199,7 +200,11 @@ func (bs *WindowsBuildServerConfig) GetServiceAccountEmail(projectID string) str
 }
 
 func (bs *WindowsBuildServerConfig) GetLabelsMap() map[string]string {
-	var labelsMap = map[string]string{"builder_version": strings.ToLower(*bs.ImageVersion)}
+	var labelsMap = map[string]string{}
+
+	if bs.ReuseInstance {
+		labelsMap["builder_version"] = strings.ToLower(*bs.ImageVersion)
+	}
 
 	if *bs.Labels == "" {
 		return labelsMap

--- a/gke-windows-builder/builder/builder/remote.go
+++ b/gke-windows-builder/builder/builder/remote.go
@@ -40,6 +40,7 @@ type RemoteWindowsServer struct {
 // WindowsBuildServerConfig stores the configs of windows build server.
 type WindowsBuildServerConfig struct {
 	InstanceNamePrefix *string
+	ImageVersion       *string
 	ImageURL           *string
 	Zone               *string
 	NetworkConfig      *InstanceNetworkConfig
@@ -198,11 +199,11 @@ func (bs *WindowsBuildServerConfig) GetServiceAccountEmail(projectID string) str
 }
 
 func (bs *WindowsBuildServerConfig) GetLabelsMap() map[string]string {
-	if *bs.Labels == "" {
-		return nil
-	}
+	var labelsMap = map[string]string{"builder_version": strings.ToLower(*bs.ImageVersion)}
 
-	var labelsMap map[string]string
+	if *bs.Labels == "" {
+		return labelsMap
+	}
 
 	for _, label := range strings.Split(*bs.Labels, ",") {
 		labelSpl := strings.Split(label, "=")
@@ -218,9 +219,6 @@ func (bs *WindowsBuildServerConfig) GetLabelsMap() map[string]string {
 		}
 		var value = strings.TrimSpace(labelSpl[1])
 
-		if labelsMap == nil {
-			labelsMap = make(map[string]string)
-		}
 		labelsMap[key] = value
 	}
 	return labelsMap

--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -259,6 +259,7 @@ func buildSingleArchContainer(ctx context.Context, ver string, imageFamily strin
 	}
 
 	if reuseBuilderInstances != nil {
+		log.Printf("Looking for an exiting %s instance to reuse", ver)
 		s, err = builder.FindExistingInstance(ctx, bsc, *projectID)
 	}
 

--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -48,7 +48,7 @@ var (
 	serviceAccount        = flag.String("serviceAccount", "default", "The service account to use when creating the Windows Instance")
 	containerImageName    = flag.String("container-image-name", "", "The target container image:tag name")
 	pickedVersions        = flag.String("versions", "", "List of Windows Server versions user wants to support. If not provided, the container will be built to support all Windows versions that GKE supports")
-	reuseBuilderInstances = flag.Bool("reuse-builder-instances", false, "Look for existing instances by labels and instance-name-prefix and reuse them for build. Create new instance only if none were found")
+	reuseBuilderInstances = flag.Bool("reuse-builder-instances", false, "Look for existing instances by labels and instance-name-prefix and reuse them for build, create new instance only if none were found. Avoid when queuing parallel builds.")
 	instanceNamePrefix    = flag.String("instance-name-prefix", "windows-builder-", "Prefix to use for created GCE instances. Defaults to 'windows-builder-'")
 	testObsoleteVersion   = flag.Bool("testonly-test-obsolete-versions", false, "If true, verify the obsolete Windows versions won't fail the builder. For testing purposes only")
 	setupTimeout          = flag.Duration("setup-timeout", 20*time.Minute, "Time out to wait for Windows instance to be ready for winrm connection and Docker setup")
@@ -256,6 +256,7 @@ func buildSingleArchContainer(ctx context.Context, ver string, imageFamily strin
 		ServiceAccount:     serviceAccount,
 		UseInternalIP:      *useInternalIP,
 		ExternalNAT:        *ExternalIP,
+		ReuseInstance:      *reuseBuilderInstances,
 	}
 
 	if reuseBuilderInstances != nil {


### PR DESCRIPTION
As most of the build time is spent on spinning up new Windows GCE instances and waiting for them to install docker and other dependencies, it makes a lot of sense to use already created windows instances.

In this PR i add the following flags:
--reuse-builder-instances: Look for existing instances by labels and instance-name-prefix and reuse them for build. Create new instance only if none were found. Do not delete the instance after the build.
--instance-name-prefix: allows setting your own name prefix for the created VMs