### PR TITLE
Fix issues with location restriction org policy and with subnet names

### DIFF
--- a/gke-windows-builder/builder/builder/bucket.go
+++ b/gke-windows-builder/builder/builder/bucket.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Create the GCS bucket if it doesn't exist. The bucket is used to copy workspace over to Windows instances.
-func NewGCSBucketIfNotExists(ctx context.Context, projectID string, workspaceBucket string) error {
+func NewGCSBucketIfNotExists(ctx context.Context, projectID string, workspaceBucket string, workspaceBucketLocation string) error {
 	if workspaceBucket == "" {
 		log.Printf("No bucket name specified, skip creating the bucket")
 		return nil
@@ -43,7 +43,7 @@ func NewGCSBucketIfNotExists(ctx context.Context, projectID string, workspaceBuc
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
-	lifecycleAttrs := &storage.BucketAttrs{
+	attrs := &storage.BucketAttrs{
 		Lifecycle: storage.Lifecycle{
 			Rules: []storage.LifecycleRule{
 				{
@@ -55,13 +55,21 @@ func NewGCSBucketIfNotExists(ctx context.Context, projectID string, workspaceBuc
 			},
 		},
 	}
+
+	if workspaceBucketLocation != "" {
+		attrs.Location = workspaceBucketLocation
+	}
+
 	bkt := client.Bucket(workspaceBucket)
 
+	// Retrieve the bucket's metadata to find if it already exists and
+	// that the code has access to the bucket
 	if _, err := bkt.Attrs(ctx); err == nil {
 		log.Printf("%v bucket already exists", workspaceBucket)
 		return nil
 	} else if err == storage.ErrBucketNotExist {
-		if err := bkt.Create(ctx, projectID, lifecycleAttrs); err == nil {
+		// The bucket does not exist. Try to create it
+		if err := bkt.Create(ctx, projectID, attrs); err == nil {
 			log.Printf("Bucket %v is setup", workspaceBucket)
 			return nil
 		} else {

--- a/gke-windows-builder/builder/builder/gce.go
+++ b/gke-windows-builder/builder/builder/gce.go
@@ -308,11 +308,9 @@ func (s *Server) newInstance(bs *WindowsBuildServerConfig) error {
 		Labels: bs.GetLabelsMap(),
 	}
 
-	networkUrl, subnetUrl := InstanceNetworkUrls(bs.NetworkConfig, s.projectID)
-	if networkUrl != "" {
-		instance.NetworkInterfaces[0].Network = networkUrl
-	}
+	subnetUrl := InstanceSubnetworkUrl(bs.NetworkConfig)
 	if subnetUrl != "" {
+		// Network will be inferred from the subnetwork
 		instance.NetworkInterfaces[0].Subnetwork = subnetUrl
 	}
 
@@ -424,7 +422,7 @@ func (s *Server) getIP(useInternalIP bool) (string, error) {
 	return "", errors.New("Could not get external NAT IP from list")
 }
 
-//WindowsPasswordConfig stores metadata to be sent to GCE.
+// WindowsPasswordConfig stores metadata to be sent to GCE.
 type WindowsPasswordConfig struct {
 	key      *rsa.PrivateKey
 	password string
@@ -435,7 +433,7 @@ type WindowsPasswordConfig struct {
 	ExpireOn time.Time `json:"expireOn"`
 }
 
-//WindowsPasswordResponse stores data received from GCE.
+// WindowsPasswordResponse stores data received from GCE.
 type WindowsPasswordResponse struct {
 	UserName          string `json:"userName"`
 	PasswordFound     bool   `json:"passwordFound"`

--- a/gke-windows-builder/builder/builder/network.go
+++ b/gke-windows-builder/builder/builder/network.go
@@ -70,21 +70,13 @@ func usingSharedVPC(netConfig *InstanceNetworkConfig) bool {
 	return false
 }
 
-// ProjectNetworkUrls returns urls for referencing the network and subnetwork
-// in the InstanceNetworkConfig as global project-level resources. If an empty
-// url string is returned then subsequent GCE API calls should leave the
-// network or subnetwork blank so that the desired behavior will be inferred.
-func ProjectNetworkUrls(netConfig *InstanceNetworkConfig, instanceProject string) (string, string) {
-	var networkUrl, subnetUrl string
-	subnetUrl = computeUrlPrefix + *netConfig.SubnetProject + "/global/networks/" + *netConfig.Subnet
-
-	if usingSharedVPC(netConfig) {
-		log.Printf("Detected Shared VPC scenario, subnet will be specified and network will be inferred")
-		return networkUrl, subnetUrl
-	}
+// ProjectNetworkUrls returns urls for referencing the network
+// in the InstanceNetworkConfig as global project-level resources.
+func ProjectNetworkUrls(netConfig *InstanceNetworkConfig, instanceProject string) string {
+	var networkUrl string
 
 	networkUrl = computeUrlPrefix + *netConfig.NetworkProject + "/global/networks/" + *netConfig.Network
-	return networkUrl, subnetUrl
+	return networkUrl
 }
 
 // InstanceNetworkUrls returns urls for referencing the network and subnetwork
@@ -117,9 +109,9 @@ func CheckProjectFirewalls(ctx context.Context, netConfig *InstanceNetworkConfig
 		return fmt.Errorf("Failed to start GCE service for setup: %+v", err)
 	}
 
-	networkUrl, subnetUrl := ProjectNetworkUrls(netConfig, instanceProject)
+	networkUrl := ProjectNetworkUrls(netConfig, instanceProject)
 	projects := []string{*netConfig.NetworkProject, *netConfig.SubnetProject}
-	for i, url := range []string{networkUrl, subnetUrl} {
+	for i, url := range []string{networkUrl} {
 		if url == "" {
 			continue
 		}

--- a/gke-windows-builder/builder/builder/network.go
+++ b/gke-windows-builder/builder/builder/network.go
@@ -28,73 +28,57 @@ type InstanceNetworkConfig struct {
 	Network        *string
 	NetworkProject *string
 	Subnet         *string
-	SubnetProject  *string
 	Region         *string
 }
 
 // NewInstanceNetworkConfig returns a pointer to a new InstanceNetworkConfig
 // struct whose fields have been set correctly based on the flag values passed
 // as args.
-func NewInstanceNetworkConfig(instanceProject *string, network *string, networkProject *string, subnet *string, subnetProject *string, region *string) *InstanceNetworkConfig {
+func NewInstanceNetworkConfig(instanceProject *string, network *string, networkProject *string, subnet *string, region *string) *InstanceNetworkConfig {
 	netConfig := InstanceNetworkConfig{
 		Network:        network,
 		NetworkProject: networkProject,
 		Subnet:         subnet,
-		SubnetProject:  subnetProject,
 		Region:         region,
 	}
-	if usingSharedVPC(&netConfig) {
+	if usingSharedVPC(&netConfig, instanceProject) {
 		// When Shared VPC is detected, we do not make any assumptions
 		// about the networks / projects other than what the user
 		// passed as args.
 		return &netConfig
 	}
 
+	// Infer network project from instance project
 	if *netConfig.NetworkProject == "" {
 		netConfig.NetworkProject = instanceProject
 	}
-	if *netConfig.SubnetProject == "" {
-		netConfig.SubnetProject = instanceProject
-	}
+
 	return &netConfig
 }
 
-func usingSharedVPC(netConfig *InstanceNetworkConfig) bool {
-	if *netConfig.SubnetProject != "" && *netConfig.NetworkProject == "" {
-		// If --subnetwork-project was specified but --network-project
-		// was not, this indicates that the user is specifying a Shared
-		// VPC subnet and we should let the --network be inferred (this
-		// is what the Cloud Console does when using Shared VPC).
+func usingSharedVPC(netConfig *InstanceNetworkConfig, instanceProject *string) bool {
+	if *netConfig.NetworkProject != "" && *netConfig.NetworkProject != *instanceProject {
+		// If --network-project was set and is different than the instance project
+		// this indicates that the user is using a Shared VPC
 		return true
 	}
 	return false
 }
 
-// ProjectNetworkUrls returns urls for referencing the network
+// ProjectNetworkUrl returns a url for referencing the network
 // in the InstanceNetworkConfig as global project-level resources.
-func ProjectNetworkUrls(netConfig *InstanceNetworkConfig, instanceProject string) string {
+func ProjectNetworkUrl(netConfig *InstanceNetworkConfig) string {
 	var networkUrl string
 
 	networkUrl = computeUrlPrefix + *netConfig.NetworkProject + "/global/networks/" + *netConfig.Network
 	return networkUrl
 }
 
-// InstanceNetworkUrls returns urls for referencing the network and subnetwork
+// InstanceSubnetworkUrl returns a url for referencing the subnetwork
 // in the InstanceNetworkConfig during instance creation. The network url will
-// be a global resource and the subnet url will be a regional resource.  If an
-// empty url string is returned then it does not need to be specified during
-// instance creation and it will be inferred by the GCE API.
-func InstanceNetworkUrls(netConfig *InstanceNetworkConfig, instanceProject string) (string, string) {
-	var networkUrl, subnetUrl string
-	subnetUrl = computeUrlPrefix + *netConfig.SubnetProject + "/regions/" + *netConfig.Region + "/subnetworks/" + *netConfig.Subnet
-
-	if usingSharedVPC(netConfig) {
-		log.Printf("Detected Shared VPC scenario, subnet will be specified and network will be inferred")
-		return networkUrl, subnetUrl
-	}
-
-	networkUrl = computeUrlPrefix + *netConfig.SubnetProject + "/global/networks/" + *netConfig.Network
-	return networkUrl, subnetUrl
+// inferred by the GCE API.
+func InstanceSubnetworkUrl(netConfig *InstanceNetworkConfig) string {
+	return computeUrlPrefix + *netConfig.NetworkProject + "/regions/" + *netConfig.Region + "/subnetworks/" + *netConfig.Subnet
 }
 
 // CheckProjectFirewalls verifies that the projects in the
@@ -102,24 +86,21 @@ func InstanceNetworkUrls(netConfig *InstanceNetworkConfig, instanceProject strin
 // controlling the builder VMs. Returns an error if user action is required to
 // configure the firewall rules, or nil if the firewall rules are set up
 // properly.
-func CheckProjectFirewalls(ctx context.Context, netConfig *InstanceNetworkConfig, instanceProject string) error {
+func CheckProjectFirewalls(ctx context.Context, netConfig *InstanceNetworkConfig) error {
 	var err error
 	var gceService *compute.Service
 	if gceService, err = newGCEService(ctx); err != nil {
 		return fmt.Errorf("Failed to start GCE service for setup: %+v", err)
 	}
 
-	networkUrl := ProjectNetworkUrls(netConfig, instanceProject)
-	projects := []string{*netConfig.NetworkProject, *netConfig.SubnetProject}
-	for i, url := range []string{networkUrl} {
-		if url == "" {
-			continue
-		}
-		log.Printf("Checking WinRM firewall rule is present for project %s, network %s", projects[i], url)
-		if !winRMIngressIsAllowed(gceService, projects[i], url) {
-			return fmt.Errorf("Project %s does not have a firewall rule to allow WinRM ingress. Please run:\n  gcloud compute firewall-rules create --project=%s allow-winrm-ingress --allow=tcp:5986 --direction=INGRESS --network=%s", projects[i], projects[i], url)
-		}
+	networkUrl := ProjectNetworkUrl(netConfig)
+	project := *netConfig.NetworkProject
+
+	log.Printf("Checking WinRM firewall rule is present for project %s, network %s", project, networkUrl)
+	if !winRMIngressIsAllowed(gceService, project, networkUrl) {
+		return fmt.Errorf("Project %s does not have a firewall rule to allow WinRM ingress. Please run:\n  gcloud compute firewall-rules create --project=%s allow-winrm-ingress --allow=tcp:5986 --direction=INGRESS --network=%s", project, project, networkUrl)
 	}
+
 	return nil
 }
 

--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -137,7 +137,11 @@ func setupProjectForBuilder(ctx context.Context) error {
 		return fmt.Errorf("Failed creating bucket: %v, with error: %+v", *workspaceBucket, err)
 	}
 
-	if *skipFirewallCheck || *useInternalIP {
+	if *useInternalIP {
+		log.Printf("Using a VM without an external IP. Make sure your build is using a worker pool connected to the specified network.")
+	}
+
+	if *skipFirewallCheck {
 		log.Printf("skipping checks that WinRM firewall rules exist")
 		return nil
 	}


### PR DESCRIPTION
1. Fix location restriction org policy by changing bucket exist test from POST to GET.
https://github.com/GoogleCloudPlatform/kubernetes-engine-windows-tools/issues/15
2. Add parameter workspace-bucket-location to select desired location for the bucket (default is "" which is US).
3. Fix issue when subnet is named differently than network by removing checking FW rule for subnet name. 
https://github.com/GoogleCloudPlatform/kubernetes-engine-windows-tools/issues/14