### PR TITLE
Add support for Windows Server 2022 LTSC

### DIFF
--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -64,6 +64,7 @@ var (
 		"2004":     "windows-cloud/global/images/family/windows-2004-core",
 		"20H2":     "windows-cloud/global/images/family/windows-20h2-core",
 		"ltsc2019": "windows-cloud/global/images/family/windows-2019-core-for-containers",
+		"ltsc2022": "windows-cloud/global/images/family/windows-2022-core",
 	}
 	commandTimeout = 10 * time.Minute
 )


### PR DESCRIPTION
Note that the DockerMsftProvider module is no longer active. This means that windows server images earlier than 2022 must already have docker as part of their image, as in the case of the Windows Server 2019 image.