### PR TITLE
Switch to use Docker CE for both 2019 & 2022 + Fix docker check

### DIFF
--- a/gke-windows-builder/builder/builder/gce.go
+++ b/gke-windows-builder/builder/builder/gce.go
@@ -67,7 +67,8 @@ function Install-ContainersFeature {
 	Install-WindowsFeature Containers
 }
 function Test-DockerIsInstalled {
-	return ((Get-Package -ProviderName DockerMsftProvider -ErrorAction SilentlyContinue | Where-Object Name -eq 'docker') -ne $null)
+	$service = Get-Service -Name docker -ErrorAction SilentlyContinue
+	return ($service -ne $null)
 }
 function Test-DockerIsRunning {
 	return ((Get-Service docker).Status -eq 'Running')
@@ -76,11 +77,6 @@ function Test-DockerIsRunning {
 # Containers feature is installed before calling this function; otherwise,
 # a restart may be needed after this function returns.
 function Install-Docker {
-	# Docker CE is supported for Windows Server 2022 and on
-	if ([System.Environment]::OSVersion.Version.Build -lt 20348) {
-		throw "This version of Windows is incompatible with Docker CE"
-	}
-
 	# Based on https://learn.microsoft.com/virtualization/windowscontainers/quick-start/set-up-environment?tabs=dockerce#windows-server-1
 	Write-Host "Installing latest Docker CE version"
 	$scriptFile = "$env:Temp\install-docker-ce.ps1"

--- a/gke-windows-builder/builder/builder/network.go
+++ b/gke-windows-builder/builder/builder/network.go
@@ -114,7 +114,7 @@ func winRMIngressIsAllowed(service *compute.Service, networkProject string, netw
 	}
 	for _, rule := range firewalls.Items {
 		for _, allowed := range rule.Allowed {
-			if rule.Network == networkUrl && rule.Direction == "INGRESS" && allowed.IPProtocol == "tcp" && rule.SourceRanges[0] == "0.0.0.0/0" && !rule.Disabled {
+			if rule.Network == networkUrl && rule.Direction == "INGRESS" && allowed.IPProtocol == "tcp" && len(rule.SourceRanges) > 0 && rule.SourceRanges[0] == "0.0.0.0/0" && !rule.Disabled {
 				for _, port := range allowed.Ports {
 					if port == "5986" {
 						log.Printf("found an INGRESS firewall rule for tcp:5986 in project %s", networkProject)

--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -63,7 +63,7 @@ var (
 	versionMap = map[string]string{
 		"2004":     "windows-cloud/global/images/family/windows-2004-core",
 		"20H2":     "windows-cloud/global/images/family/windows-20h2-core",
-		"ltsc2019": "windows-cloud/global/images/family/windows-2019-core-for-containers",
+		"ltsc2019": "windows-cloud/global/images/family/windows-2019-core",
 		"ltsc2022": "windows-cloud/global/images/family/windows-2022-core",
 	}
 	commandTimeout = 10 * time.Minute


### PR DESCRIPTION
The change switches the usage completely from *-for-containers images for both 2019 & 2022. Docker CE will be required to be installed as part of the initialization. It includes a fix as well to handle the check for docker properly (in case MCR bases are used in future).