### PR TITLE
Fix a bug where windows builder would always try to reuse the builders

### DIFF
--- a/gke-windows-builder/builder/main.go
+++ b/gke-windows-builder/builder/main.go
@@ -273,7 +273,7 @@ func buildSingleArchContainer(ctx context.Context, ver string, imageFamily strin
 		ReuseInstance:      *reuseBuilderInstances,
 	}
 
-	if reuseBuilderInstances != nil {
+	if *reuseBuilderInstances {
 		log.Printf("Looking for an exiting %s instance to reuse", ver)
 		s, err = builder.FindExistingInstance(ctx, bsc, *projectID)
 	}


### PR DESCRIPTION
but would delete them at the end because of incorrect value check for reuse builders paramter